### PR TITLE
Improve plugin performance on slow machines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     compileOnly("dev.jorel:commandapi-annotations:10.0.1")
     implementation("com.github.walker84837:JResult:1.3.0")
     testImplementation("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.13.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.12.2")
     annotationProcessor("dev.jorel:commandapi-annotations:10.0.1")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,11 @@ repositories {
             includeModule("com.mojang", "brigadier")
         }
     }
+    
+    maven {
+        name = "winlogon"
+        url = uri("https://maven.winlogon.org/releases")
+    }
 
     maven {
         name = "jitpack"
@@ -71,10 +76,13 @@ repositories {
 
 dependencies {
     annotationProcessor("dev.jorel:commandapi-annotations:10.0.1")
+
     compileOnly("dev.jorel:commandapi-annotations:10.0.1")
-    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.6-R0.1-SNAPSHOT")
+    compileOnly("org.winlogon:asynccraftr:0.1.0")
+
     implementation("com.github.walker84837:JResult:1.3.0")
-    testImplementation("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-api:1.21.6-R0.1-SNAPSHOT")
     testImplementation("org.junit.jupiter:junit-jupiter:5.13.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.13.1")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,10 +70,10 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.6-R0.1-SNAPSHOT")
     compileOnly("dev.jorel:commandapi-annotations:10.0.1")
     implementation("com.github.walker84837:JResult:1.3.0")
-    testImplementation("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-api:1.21.6-R0.1-SNAPSHOT")
     testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.12.2")
     annotationProcessor("dev.jorel:commandapi-annotations:10.0.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ dependencies {
     implementation("com.github.walker84837:JResult:1.3.0")
     testImplementation("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.12.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.13.1")
     annotationProcessor("dev.jorel:commandapi-annotations:10.0.1")
 }
 

--- a/src/main/java/org/winlogon/simplertp/LocationPool.java
+++ b/src/main/java/org/winlogon/simplertp/LocationPool.java
@@ -1,10 +1,11 @@
 package org.winlogon.simplertp;
 
+import org.bukkit.Location;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import org.jetbrains.annotations.Nullable;
-import org.bukkit.Location;
 
 public class LocationPool {
     // thread‑safe queue of pre‑validated safe locations

--- a/src/main/java/org/winlogon/simplertp/LocationPool.java
+++ b/src/main/java/org/winlogon/simplertp/LocationPool.java
@@ -1,0 +1,33 @@
+package org.winlogon.simplertp;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.jetbrains.annotations.Nullable;
+import org.bukkit.Location;
+
+public class LocationPool {
+    // thread‑safe queue of pre‑validated safe locations
+    private final ConcurrentLinkedQueue<Location> ready = new ConcurrentLinkedQueue<>();
+    // keeps track of which coords have been handed out already
+    private final Set<Long> used = ConcurrentHashMap.newKeySet();
+
+    /** Offer a location if we haven’t used it yet. */
+    public void offer(Location loc) {
+        long key = pack(loc);
+        if (used.contains(key) || ready.stream().anyMatch(l -> pack(l) == key)) return;
+        ready.offer(loc);
+    }
+
+    /** Poll the next ready location, marking it used. */
+    public @Nullable Location poll() {
+        Location loc = ready.poll();
+        if (loc != null) used.add(pack(loc));
+        return loc;
+    }
+
+    private long pack(Location loc) {
+        // x,z fit in 32 bits each; combine into single long
+        return (((long)loc.getBlockX()) << 32) | (loc.getBlockZ() & 0xFFFFFFFFL);
+    }
+}

--- a/src/main/java/org/winlogon/simplertp/LocationPool.java
+++ b/src/main/java/org/winlogon/simplertp/LocationPool.java
@@ -11,9 +11,16 @@ public class LocationPool {
     private final ConcurrentLinkedQueue<Location> ready = new ConcurrentLinkedQueue<>();
     // keeps track of which coords have been handed out already
     private final Set<Long> used = ConcurrentHashMap.newKeySet();
+    private final int maxSize;
+
+    public LocationPool(int maxSize) {
+        this.maxSize = maxSize;
+    }
 
     /** Offer a location if we haven’t used it yet. */
     public void offer(Location loc) {
+        if (ready.size() >= maxSize) return;
+        
         long key = pack(loc);
         if (used.contains(key) || ready.stream().anyMatch(l -> pack(l) == key)) return;
         ready.offer(loc);

--- a/src/main/java/org/winlogon/simplertp/LocationPool.java
+++ b/src/main/java/org/winlogon/simplertp/LocationPool.java
@@ -3,13 +3,15 @@ package org.winlogon.simplertp;
 import org.bukkit.Location;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class LocationPool {
     // thread‑safe queue of pre‑validated safe locations
-    private final ConcurrentLinkedQueue<Location> ready = new ConcurrentLinkedQueue<>();
+    private final List<Location> ready = Collections.synchronizedList(new ArrayList<>());
     // keeps track of which coords have been handed out already
     private final Set<Long> used = ConcurrentHashMap.newKeySet();
     private final int maxSize;
@@ -20,18 +22,27 @@ public class LocationPool {
 
     /** Offer a location if we haven’t used it yet. */
     public void offer(Location loc) {
-        if (ready.size() >= maxSize) return;
-        
-        long key = pack(loc);
-        if (used.contains(key) || ready.stream().anyMatch(l -> pack(l) == key)) return;
-        ready.offer(loc);
+        synchronized (ready) {
+            if (ready.size() >= maxSize) return;
+
+            long key = pack(loc);
+            if (used.contains(key) || ready.stream().anyMatch(l -> pack(l) == key)) return;
+            ready.add(loc);
+
+            // shuffle so future poll() is random
+            Collections.shuffle(ready);
+        }
     }
 
     /** Poll the next ready location, marking it used. */
     public @Nullable Location poll() {
-        Location loc = ready.poll();
-        if (loc != null) used.add(pack(loc));
-        return loc;
+        synchronized (ready) {
+            if (ready.isEmpty()) return null;
+
+            Location loc = ready.remove(0);
+            used.add(pack(loc));
+            return loc;
+        }
     }
 
     private long pack(Location loc) {

--- a/src/main/java/org/winlogon/simplertp/LocationPreloader.java
+++ b/src/main/java/org/winlogon/simplertp/LocationPreloader.java
@@ -1,100 +1,55 @@
 package org.winlogon.simplertp;
 
-import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
-import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
+import org.bukkit.ChunkSnapshot;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.scheduler.BukkitScheduler;
-import org.bukkit.scheduler.BukkitTask;
+import org.winlogon.asynccraftr.AsyncCraftr.Task;
+import org.winlogon.asynccraftr.AsyncCraftr;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.Optional;
-import java.util.logging.Logger;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 
 public class LocationPreloader {
     private static final Set<Material> UNSAFE_BLOCKS = EnumSet.of(
         Material.LAVA, Material.WATER, Material.FIRE, Material.CACTUS, Material.MAGMA_BLOCK
     );
     private final SimpleRtp plugin;
-
-    private boolean isFolia;
-    private GlobalRegionScheduler globalScheduler = null;
-    private final BukkitScheduler bukkitScheduler;
+    private Task task;
 
     private final int maxPoolSize;
     private final LocationPool pool;
     private final Logger logger;
 
-    private final ExecutorService executor;
-
-    private BukkitTask bukkitTask;
-
-    public LocationPreloader(SimpleRtp plugin, ExecutorService service, Logger logger) {
+    public LocationPreloader(SimpleRtp plugin, Logger logger) {
         var config = plugin.getRtpConfig();
 
         this.plugin = plugin;
         this.logger = logger;
         this.maxPoolSize = config.maxPoolSize();
-        this.bukkitScheduler = plugin.getServer().getScheduler();
-        this.executor = service;
 
         this.pool = new LocationPool(maxPoolSize);
-        try {
-            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
-            globalScheduler = Bukkit.getGlobalRegionScheduler();
-            isFolia = true;
-        } catch (ClassNotFoundException _) {
-            isFolia = false;
-        }
     }
 
     /** Kick off the repeating generation task. */
     public void start() {
         logger.info("Starting location preloader service");
-        var intervalHours = plugin.getConfig().getInt("preload-interval-hours", 1);
-        if (isFolia) {
-            // Convert hours to ticks (20 ticks/sec * 3600 sec/hr)
-            long periodTicks = intervalHours * 72000L;
-            globalScheduler.runAtFixedRate(
-                plugin,
-                task -> generateSomeSafeLocations(),
-                periodTicks,
-                periodTicks
-            );
-        } else {
-            // Run on main thread to avoid concurrency issues
-            long ticks = TimeUnit.HOURS.toSeconds(intervalHours) * 20;
-            bukkitTask = bukkitScheduler.runTaskTimer(
-                plugin,
-                this::generateSomeSafeLocations,
-                0L,
-                ticks
-            );
-        }
-    }
-
-    private void generateSomeSafeLocations() {
-        logger.info("Generating some safe locations");
-        if (isFolia) {
-            executor.submit(this::doGenerateSafeLocations);
-        } else {
-            doGenerateSafeLocations();
-        }
+        var configInterval = plugin.getConfig().getInt("preload-interval-hours", 1);
+        var interval = Duration.ofHours(configInterval);
+        task = AsyncCraftr.runAsyncTaskTimer(plugin, this::generateSafeLocations, Duration.ZERO, interval);
     }
 
     /** Stop the repeating task. */
     public void stop() {
         logger.info("Stopping location preloader");
-        if (!isFolia && bukkitTask != null) {
-            bukkitTask.cancel();
+        if (task != null) {
+            task.cancel();
         }
     }
 
@@ -103,130 +58,83 @@ public class LocationPreloader {
         return Optional.ofNullable(pool.poll());
     }
 
-    private void doGenerateSafeLocations() {
+    private void generateSafeLocations() {
         World world = plugin.getServer().getWorlds().get(0);
-        int chunkAttempts = 0;
-        int found = 0;
         int maxChunkAttempts = plugin.getConfig().getInt("max-chunk-attempts", 20);
         int toFind = plugin.getConfig().getInt("locations-per-hour", 5);
         int samplesPerChunk = plugin.getRtpConfig().samplesPerChunk();
+        Logger logger = this.logger;
 
-        while (chunkAttempts++ < maxChunkAttempts && found < toFind) {
-            Location chunkLoc = pickRandomXZ(world);
-            int chunkX = chunkLoc.getBlockX() >> 4;
-            int chunkZ = chunkLoc.getBlockZ() >> 4;
-            
-            Chunk chunk;
-            // asynchronous loading for Folia
-            if (isFolia) {
-                CompletableFuture<Chunk> future = new CompletableFuture<>();
-                world.getChunkAtAsync(chunkX, chunkZ, true, future::complete);
-                try {
-                    chunk = future.join();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    continue;
+        logger.info("Starting preload: maxChunkAttempts=" + maxChunkAttempts
+                + ", toFind=" + toFind + ", samplesPerChunk=" + samplesPerChunk);
+
+        AtomicInteger attempts = new AtomicInteger(0);
+        AtomicInteger found = new AtomicInteger(0);
+
+        CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
+
+        for (int i = 0; i < maxChunkAttempts; i++) {
+            chain = chain.thenCompose(unused -> {
+                if (found.get() >= toFind) {
+                    return CompletableFuture.completedFuture(null);
                 }
-            // synchronous loading for Bukkit
-            } else {
-                if (!world.isChunkLoaded(chunkX, chunkZ)) {
-                    world.loadChunk(chunkX, chunkZ);
-                }
-                chunk = world.getChunkAt(chunkX, chunkZ);
-            }
-            
-            var snap = chunk.getChunkSnapshot();
-            
-            // sample multiple locations in chunk
-            for (int i = 0; i < samplesPerChunk && found < toFind; i++, found++) {
-                int localX = ThreadLocalRandom.current().nextInt(16);
-                int localZ = ThreadLocalRandom.current().nextInt(16);
-                int x = (chunkX << 4) + localX;
-                int z = (chunkZ << 4) + localZ;
-                Location loc = new Location(world, x, 0, z);
-                
-                if (!isWithinWorldBorder(world, loc) || !isOutsideMinRange(world, loc)) {
-                    continue;
-                }
-                
-                int highestY = snap.getHighestBlockYAt(localX, localZ);
-                if (highestY < world.getMinHeight() || highestY >= world.getMaxHeight() - 2) continue;
-                
-                var above1 = snap.getBlockType(localX, highestY + 1, localZ);
-                var above2 = snap.getBlockType(localX, highestY + 2, localZ);
-                var below = snap.getBlockType(localX, highestY - 1, localZ);
-                
-                if (above1 == Material.AIR && 
-                    above2 == Material.AIR && 
-                    !UNSAFE_BLOCKS.contains(below)) {
-                    
-                    loc.setY(highestY + 1);
-                    loc.setX(loc.getBlockX() + 0.5);
-                    loc.setZ(loc.getBlockZ() + 0.5);
-                    pool.offer(loc);
-                    found++;
-                }
-            }
+                int chunkX = ThreadLocalRandom.current().nextInt(getRange(world) * 2) - getRange(world);
+                int chunkZ = ThreadLocalRandom.current().nextInt(getRange(world) * 2) - getRange(world);
+                return world.getChunkAtAsync(chunkX, chunkZ, true).thenAccept(chunk -> {
+                    attempts.incrementAndGet();
+                    var snap = chunk.getChunkSnapshot();
+                    for (int s = 0; s < samplesPerChunk && found.get() < toFind; s++) {
+                        int localX = ThreadLocalRandom.current().nextInt(16);
+                        int localZ = ThreadLocalRandom.current().nextInt(16);
+                        int x = (chunk.getX() << 4) + localX;
+                        int z = (chunk.getZ() << 4) + localZ;
+                        if (!isValidChunkSample(world, snap, x, z)) continue;
+                        Location loc = new Location(world, x + .5, snap.getHighestBlockYAt(localX, localZ) + 1, z + .5);
+                        pool.offer(loc);
+                        found.incrementAndGet();
+                    }
+                }).exceptionally(ex -> {
+                    logger.warning("Async chunk load failed: " + ex);
+                    return null;
+                });
+            });
         }
+
+        chain.whenComplete((v, ex) -> {
+            logger.info("Preload cycle done: attempted " + attempts.get()
+                    + " chunks, found " + found.get() + " locations.");
+        });
     }
 
-    private Location pickRandomXZ(World world) {
-        int maxRange = (int) getMaxRange(world, plugin.getConfig(), 3000);
-        int x = ThreadLocalRandom.current().nextInt(maxRange * 2) - maxRange;
-        int z = ThreadLocalRandom.current().nextInt(maxRange * 2) - maxRange;
-        return new Location(world, x, 0, z);
+    private int getRange(World w) {
+        int minRange = plugin.getConfig().getInt("min-range", 3000);
+        double borderRange = w.getWorldBorder().getSize() / 2.0;
+        double cfgMax = plugin.getConfig().getDouble("max-range", borderRange);
+        return (int)Math.max(minRange, Math.min(cfgMax, borderRange));
     }
 
-    private double getMaxRange(World world, FileConfiguration config, int minRange) {
-        var border = world.getWorldBorder();
-        double defaultMaxRange = border.getSize() / 2;
-        double configMaxRange = config.getDouble("max-range", defaultMaxRange);
-        return Math.max(minRange, Math.min(configMaxRange, defaultMaxRange));
-    }
+    private boolean isValidChunkSample(World world, ChunkSnapshot snap, int x, int z) {
+        Location location = new Location(world, x, 0, z);
 
-    private boolean isWithinWorldBorder(World w, Location loc) {
-        return w.getWorldBorder().isInside(loc);
-    }
+        var spawnLocation = world.getSpawnLocation();
+        var minRange = plugin.getConfig().getInt("min-range", 3000);
+        var distanceFromSpawn = spawnLocation.distanceSquared(new Location(world, x, spawnLocation.getY(), z));
 
-    private boolean isOutsideMinRange(World w, Location loc) {
-        Location spawn = w.getSpawnLocation();
-        double minRange = plugin.getConfig().getDouble("min-range", 3000);
-        return spawn.distanceSquared(
-            new Location(w, loc.getBlockX(), spawn.getY(), loc.getBlockZ())
-        ) >= minRange * minRange;
-    }
-
-    // TODO: should this method be used in the case the location pool is empty?
-    private static int findSafeY(World world, int x, int z) {
-        int minHeight = world.getMinHeight();
-        int high = world.getMaxHeight();
-        int low = (int) (minHeight + (high - minHeight) / 3.75);
-        int highestSolidY = -1;
-        
-        while (low <= high) {
-            int mid = (low + high) / 2;
-            Material block = world.getBlockAt(x, mid, z).getType();
-            
-            if (block.isSolid()) {
-                highestSolidY = mid;
-                low = mid + 1;
-            } else {
-                high = mid - 1;
-            }
+        if (!world.getWorldBorder().isInside(location) || distanceFromSpawn < Math.pow(minRange, 2)) {
+            return false;
         }
-        
-        if (highestSolidY == -1) {
-            return -1;
-        }
-        
-        var above1 = world.getBlockAt(x, highestSolidY + 1, z).getType();
-        var above2 = world.getBlockAt(x, highestSolidY + 2, z).getType();
-        if (above1 != Material.AIR || above2 != Material.AIR) {
-            return -1;
-        }
-        
-        var below = world.getBlockAt(x, highestSolidY - 1, z).getType();
-        return UNSAFE_BLOCKS.contains(below) ? -1 : highestSolidY;
+
+        int localX = x & 0xF, localZ = z & 0xF;
+        int y = snap.getHighestBlockYAt(localX, localZ);
+
+        if (y < world.getMinHeight() || y >= world.getMaxHeight() - 2) return false;
+
+        Material below = snap.getBlockType(localX, y - 1, localZ);
+        Material foot = snap.getBlockType(localX, y + 1, localZ);
+        Material head = snap.getBlockType(localX, y + 2, localZ);
+
+        return foot == Material.AIR
+            && head == Material.AIR
+            && !LocationPreloader.UNSAFE_BLOCKS.contains(below);
     }
 }
-

--- a/src/main/java/org/winlogon/simplertp/LocationPreloader.java
+++ b/src/main/java/org/winlogon/simplertp/LocationPreloader.java
@@ -1,0 +1,160 @@
+package org.winlogon.simplertp;
+
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.EnumSet;
+import java.util.Set;
+
+public class LocationPreloader {
+    private static final Set<Material> UNSAFE_BLOCKS = EnumSet.of(
+        Material.LAVA, Material.WATER, Material.FIRE, Material.CACTUS, Material.MAGMA_BLOCK
+    );
+    private final Plugin plugin;
+    private final LocationPool pool = new LocationPool();
+
+    private final boolean isFolia;
+    private final GlobalRegionScheduler globalScheduler; // only non-null on Folia
+    private final BukkitScheduler bukkitScheduler; // only non-null off-Folia
+
+    private BukkitTask bukkitTask;
+
+    public LocationPreloader(Plugin plugin) {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            this.globalScheduler = Bukkit.getGlobalRegionScheduler(); // Now using GlobalRegionScheduler
+            this.isFolia = true;
+        } catch (ClassNotFoundException e) {
+            this.isFolia = false;
+        }
+    }
+
+    /** Kick off the repeating generation task. */
+    public void start() {
+        var intervalHours = plugin.getConfig().getInt("preload-interval-hours", 1);
+        if (isFolia) {
+            // Convert hours to ticks (20 ticks/sec * 3600 sec/hr)
+            long periodTicks = intervalHours * 72000L;
+            globalScheduler.runAtFixedRate(
+                plugin,
+                task -> generateSomeSafeLocations(),
+                0,
+                periodTicks
+            );
+        } else {
+            // Run on main thread to avoid concurrency issues
+            long ticks = TimeUnit.HOURS.toSeconds(intervalHours) * 20;
+            bukkitTask = bukkitScheduler.runTaskTimer(
+                plugin,
+                this::generateSomeSafeLocations,
+                0L,
+                ticks
+            );
+        }
+    }
+
+    /** Stop the repeating task. */
+    public void stop() {
+        if (!isFolia && bukkitTask != null) {
+            bukkitTask.cancel();
+        }
+    }
+
+    /** Poll a preloaded location, if available. */
+    public Optional<Location> nextPreloadedLocation() {
+        return Optional.ofNullable(pool.poll());
+    }
+
+    private void generateSomeSafeLocations() {
+        World world = plugin.getServer().getWorlds().get(0);
+        int attempts = 0, found = 0;
+        int maxAttempts = plugin.getConfig().getInt("max-attempts-per-hour", 20);
+        int toFind     = plugin.getConfig().getInt("locations-per-hour", 5);
+
+        while (attempts++ < maxAttempts && found < toFind) {
+            Location loc = pickRandomXZ(world);
+            if (!isWithinWorldBorder(world, loc) || !isOutsideMinRange(world, loc)) {
+                continue;
+            }
+
+            int y = findSafeY(world, loc.getBlockX(), loc.getBlockZ());
+            if (y != -1) {
+                loc.setY(y + 1);
+                loc.setX(loc.getBlockX() + 0.5);
+                loc.setZ(loc.getBlockZ() + 0.5);
+                pool.offer(loc);
+                found++;
+            }
+        }
+    }
+
+    private Location pickRandomXZ(World world) {
+        int maxRange = (int) getMaxRange(world, plugin.getConfig(), 3000);
+        int x = ThreadLocalRandom.current().nextInt(maxRange * 2) - maxRange;
+        int z = ThreadLocalRandom.current().nextInt(maxRange * 2) - maxRange;
+        return new Location(world, x, 0, z);
+    }
+
+    private double getMaxRange(World world, FileConfiguration config, int minRange) {
+        WorldBorder border = world.getWorldBorder();
+        double defaultMaxRange = border.getSize() / 2;
+        double configMaxRange = config.getDouble("max-range", defaultMaxRange);
+        return Math.max(minRange, Math.min(configMaxRange, defaultMaxRange));
+    }
+
+    private boolean isWithinWorldBorder(World w, Location loc) {
+        return w.getWorldBorder().isInside(loc);
+    }
+
+    private boolean isOutsideMinRange(World w, Location loc) {
+        Location spawn = w.getSpawnLocation();
+        double minRange = plugin.getConfig().getDouble("min-range", 3000);
+        return spawn.distanceSquared(
+            new Location(w, loc.getBlockX(), spawn.getY(), loc.getBlockZ())
+        ) >= minRange * minRange;
+    }
+
+    private static int findSafeY(World world, int x, int z) {
+        int minHeight = world.getMinHeight();
+        int high = world.getMaxHeight();
+        int low = (int) (minHeight + (high - minHeight) / 3.75);
+        int highestSolidY = -1;
+        
+        while (low <= high) {
+            int mid = (low + high) / 2;
+            Material block = world.getBlockAt(x, mid, z).getType();
+            
+            if (block.isSolid()) {
+                highestSolidY = mid;
+                low = mid + 1;
+            } else {
+                high = mid - 1;
+            }
+        }
+        
+        if (highestSolidY == -1) {
+            return -1;
+        }
+        
+        Material above1 = world.getBlockAt(x, highestSolidY + 1, z).getType();
+        Material above2 = world.getBlockAt(x, highestSolidY + 2, z).getType();
+        if (above1 != Material.AIR || above2 != Material.AIR) {
+            return -1;
+        }
+        
+        Material below = world.getBlockAt(x, highestSolidY - 1, z).getType();
+        return UNSAFE_BLOCKS.contains(below) ? -1 : highestSolidY;
+    }
+}
+

--- a/src/main/java/org/winlogon/simplertp/RtpConfig.java
+++ b/src/main/java/org/winlogon/simplertp/RtpConfig.java
@@ -1,0 +1,9 @@
+package org.winlogon.simplertp;
+
+public record RtpConfig(
+    int minRange, 
+    int maxAttempts, 
+    int maxPoolSize, 
+    int samplesPerChunk,
+    int maxChunkAttempts
+) {}

--- a/src/main/java/org/winlogon/simplertp/RtpLoader.java
+++ b/src/main/java/org/winlogon/simplertp/RtpLoader.java
@@ -1,0 +1,41 @@
+package org.winlogon.simplertp;
+
+import io.papermc.paper.plugin.loader.library.impl.MavenLibraryResolver;
+import io.papermc.paper.plugin.loader.PluginClasspathBuilder;
+import io.papermc.paper.plugin.loader.PluginLoader;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
+
+public class RtpLoader implements PluginLoader {
+    @Override
+    public void classloader(PluginClasspathBuilder classpathBuilder) {
+        var resolver = new MavenLibraryResolver();
+
+        resolver.addRepository(
+            new RemoteRepository.Builder(
+                "central",
+                "default",
+                MavenLibraryResolver.MAVEN_CENTRAL_DEFAULT_MIRROR
+            ).build()
+        );
+
+        resolver.addRepository(
+            new RemoteRepository.Builder(
+                "winlogon",
+                "default",
+                "https://maven.winlogon.org/releases"
+            ).build()
+        );
+
+        resolver.addDependency(
+            new Dependency(
+                new DefaultArtifact("org.winlogon:asynccraftr:0.1.0"),
+                null
+            )
+        );
+
+        classpathBuilder.addLibrary(resolver);
+    }
+}

--- a/src/main/java/org/winlogon/simplertp/RtpUtils.java
+++ b/src/main/java/org/winlogon/simplertp/RtpUtils.java
@@ -1,0 +1,13 @@
+package org.winlogon.simplertp;
+
+import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
+
+public class RtpUtils {
+    public static double getMaxRange(World world, FileConfiguration config, int minRange) {
+        var border = world.getWorldBorder();
+        double defaultMaxRange = border.getSize() / 2;
+        double configMaxRange = config.getDouble("max-range", defaultMaxRange);
+        return Math.max(minRange, Math.min(configMaxRange, defaultMaxRange));
+    }
+}

--- a/src/main/java/org/winlogon/simplertp/SimpleRtp.java
+++ b/src/main/java/org/winlogon/simplertp/SimpleRtp.java
@@ -10,16 +10,18 @@ import dev.jorel.commandapi.CommandAPI;
 
 public class SimpleRtp extends JavaPlugin {
     private RegionScheduler scheduler = Bukkit.getRegionScheduler();
-    private int minRange;
-    private int maxAttempts;
     private FileConfiguration config;
-
+    private RtpConfig rtpConfig;
     private static SimpleRtp instance;
     private LocationPreloader preloader;
 
     @Override
     public void onEnable() {
+        instance = this;
+
         saveDefaultConfig();
+        loadConfig();
+
         preloader = new LocationPreloader(this);
         preloader.start();
 
@@ -39,8 +41,12 @@ public class SimpleRtp extends JavaPlugin {
     
     private void loadConfig() {
         config = getConfig();
-        minRange = config.getInt("min-range", 3000);
-        maxAttempts = config.getInt("max-attempts", 50);
+        int minRange         = config.getInt("min-range", 3000);
+        int maxAttempts      = config.getInt("max-attempts", 50);
+        int maxPoolSize      = config.getInt("max-pool-size", 100);
+        int samplesPerChunk  = config.getInt("samples-per-chunk", 8);
+        int maxChunkAttempts = config.getInt("max-chunk-attempts", 10);
+        rtpConfig = new RtpConfig(minRange, maxAttempts, maxPoolSize, samplesPerChunk, maxChunkAttempts);
     }
     
     public static SimpleRtp getInstance() {
@@ -51,12 +57,8 @@ public class SimpleRtp extends JavaPlugin {
         return config;
     }
     
-    public int getMinRange() {
-        return minRange;
-    }
-    
-    public int getMaxAttempts() {
-        return maxAttempts;
+    public RtpConfig getRtpConfig() {
+        return rtpConfig;
     }
     
     public RegionScheduler getRegionScheduler() {

--- a/src/main/java/org/winlogon/simplertp/SimpleRtp.java
+++ b/src/main/java/org/winlogon/simplertp/SimpleRtp.java
@@ -15,20 +15,26 @@ public class SimpleRtp extends JavaPlugin {
     private FileConfiguration config;
 
     private static SimpleRtp instance;
-    
+    private LocationPreloader preloader;
+
     @Override
     public void onEnable() {
-        instance = this;
         saveDefaultConfig();
-        loadConfig();
+        preloader = new LocationPreloader(this);
+        preloader.start();
 
         CommandAPI.registerCommand(RtpCommand.class);
-        getLogger().info("SimpleRTP has been enabled!");
+        getLogger().info("SimpleRTP enabled with preloader");
     }
-    
+
     @Override
     public void onDisable() {
-        getLogger().info("SimpleRTP has been disabled!");
+        preloader.stop();
+        getLogger().info("SimpleRTP disabled");
+    }
+
+    public LocationPreloader getPreloader() {
+        return preloader;
     }
     
     private void loadConfig() {

--- a/src/main/java/org/winlogon/simplertp/SimpleRtp.java
+++ b/src/main/java/org/winlogon/simplertp/SimpleRtp.java
@@ -8,10 +8,6 @@ import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
 
 import dev.jorel.commandapi.CommandAPI;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-
 public class SimpleRtp extends JavaPlugin {
     private RegionScheduler scheduler = Bukkit.getRegionScheduler();
     private static SimpleRtp instance;
@@ -20,10 +16,6 @@ public class SimpleRtp extends JavaPlugin {
     private RtpConfig rtpConfig;
 
     private LocationPreloader preloader;
-    ExecutorService executor = Executors.newThreadPerTaskExecutor(
-        Thread.ofVirtual().name("rtp-", 0).factory()
-    );
-
     private java.util.logging.Logger logger;
 
     @Override
@@ -34,7 +26,7 @@ public class SimpleRtp extends JavaPlugin {
         loadConfig();
         logger = getLogger();
 
-        preloader = new LocationPreloader(this, executor, logger);
+        preloader = new LocationPreloader(this, logger);
         preloader.start();
         logger.info("RTP preloader enabled");
 
@@ -44,7 +36,6 @@ public class SimpleRtp extends JavaPlugin {
     @Override
     public void onDisable() {
         preloader.stop();
-        executor.shutdown();
         logger.info("SimpleRTP disabled");
     }
 
@@ -76,9 +67,5 @@ public class SimpleRtp extends JavaPlugin {
     
     public RegionScheduler getRegionScheduler() {
         return scheduler;
-    }
-
-    public ExecutorService getVirtualExecutor() {
-        return executor;
     }
 }

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,6 +1,7 @@
 main: "${PACKAGE}.SimpleRtp"
 name: "${NAME}"
 version: "${VERSION}"
+loader: "${PACKAGE}.RtpLoader"
 api-version: "1.21"
 author: winlogon
 description: Teleport to a random place, safely


### PR DESCRIPTION
- Keep track of visited chunk coordinates using a `Set<Long>` with something like `chunkX << 32 | chunkZ & 0xFFFFFFFFL`, and then reset it each preload cycle(?).
- In https://github.com/WinSMP/SimpleRTP/blob/2b2f44ad8a962c9dbe21a592516438efbb74fed2/src/main/java/org/winlogon/simplertp/LocationPreloader.java#L131 only increment `found` after a successful `pool.offer(loc)`.